### PR TITLE
Hotfix: copy readme to publishManifests - fix release 1.0.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,6 +116,13 @@ jobs:
         **\*.vsix
       targetFolder: $(Build.ArtifactStagingDirectory)
   
+  - task: CopyFiles@2
+    displayName: 'Copy readme to publishManifests'
+    inputs:
+      contents: |
+        readme.md
+      targetFolder: $(Build.ArtifactStagingDirectory)\PublishManifests
+  
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Prod Artifact'
     condition: eq(variables['isMarketplaceRelease'], 'true')


### PR DESCRIPTION
During the release, release tasks are unable to find `readme.md` when publishing `vxis` to the marketplace.

This PR fixes this problem by coping `readme.md` to `PublishManifests` folder where `publishManifest2019.json` and  `publishManifest2022.json` are located.