### PR TITLE
Fix Extension Fails to Load due to Assembly Version Mismatch

### DIFF
--- a/RoslyJump.Core.xUnit/RoslyJump.Core.xUnit.csproj
+++ b/RoslyJump.Core.xUnit/RoslyJump.Core.xUnit.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/RoslyJump.Core.xUnit/RoslyJump.Core.xUnit.csproj
+++ b/RoslyJump.Core.xUnit/RoslyJump.Core.xUnit.csproj
@@ -10,7 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/RoslyJump.Core.xUnit/RoslyJump.Core.xUnit.csproj
+++ b/RoslyJump.Core.xUnit/RoslyJump.Core.xUnit.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/RoslyJump.Core/RoslyJump.Core.csproj
+++ b/RoslyJump.Core/RoslyJump.Core.csproj
@@ -8,6 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\dngrep\dngrep.core\dngrep.core.csproj" />
   </ItemGroup>
 

--- a/RoslyJump.Shared/Infrastructure/VisualStudio/TextEditor/ActiveViewAccessor.cs
+++ b/RoslyJump.Shared/Infrastructure/VisualStudio/TextEditor/ActiveViewAccessor.cs
@@ -5,14 +5,9 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 
-namespace RoslyJump.Infrastructure.VisualStudio.TextEditor
+namespace RoslyJump.Shared.Infrastructure.VisualStudio.TextEditor
 {
 #nullable enable
-    public interface IActiveViewAccessor
-    {
-        IWpfTextView? ActiveView { get; }
-    }
-
     [Export(typeof(IActiveViewAccessor))]
     internal sealed class ActiveViewAccessor : IActiveViewAccessor
     {

--- a/RoslyJump.Shared/Infrastructure/VisualStudio/TextEditor/IActiveViewAccessor.cs
+++ b/RoslyJump.Shared/Infrastructure/VisualStudio/TextEditor/IActiveViewAccessor.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.VisualStudio.Text.Editor;
+
+namespace RoslyJump.Shared.Infrastructure.VisualStudio.TextEditor
+{
+    public interface IActiveViewAccessor
+    {
+        IWpfTextView? ActiveView { get; }
+    }
+}

--- a/RoslyJump.Shared/Package/RoslyJumpPackage.cs
+++ b/RoslyJump.Shared/Package/RoslyJumpPackage.cs
@@ -14,7 +14,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Formatting;
 using RoslyJump.Core;
 using RoslyJump.Core.Contexts.Local;
-using RoslyJump.Infrastructure.VisualStudio.TextEditor;
+using RoslyJump.Shared.Infrastructure.VisualStudio.TextEditor;
 using RoslyJump.Package;
 using RoslyJump.VisualComponents.TextEditor.Adornments;
 using Task = System.Threading.Tasks.Task;

--- a/RoslyJump.Shared/RoslyJump.Shared.projitems
+++ b/RoslyJump.Shared/RoslyJump.Shared.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)GlobalSuppressions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Infrastructure\VisualStudio\TextEditor\ActiveViewAccessor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Infrastructure\VisualStudio\TextEditor\IActiveViewAccessor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Package\CommandIds.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Package\PackageIds.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Package\RoslyJumpPackage.cs" />

--- a/RoslyJump.VSIX.2022/RoslyJump.VSIX.2022.csproj
+++ b/RoslyJump.VSIX.2022/RoslyJump.VSIX.2022.csproj
@@ -67,8 +67,11 @@
     <PackageReference Include="Microsoft.CodeAnalysis">
       <Version>4.7.0</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common">
+      <Version>4.8.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>4.7.0</Version>
+      <Version>4.8.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.7.0</Version>

--- a/RoslyJump.VSIX.2022/RoslyJump.VSIX.2022.csproj
+++ b/RoslyJump.VSIX.2022/RoslyJump.VSIX.2022.csproj
@@ -65,7 +65,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>4.7.0</Version>
+      <Version>4.8.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
       <Version>4.8.0</Version>
@@ -76,10 +76,13 @@
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.7.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.7.37357" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.8.37222" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.7.2190" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.8.2365">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\dngrep\dngrep.core\dngrep.core.csproj">

--- a/RoslyJump.VSIX.2022/RoslyJump.VSIX.2022.csproj
+++ b/RoslyJump.VSIX.2022/RoslyJump.VSIX.2022.csproj
@@ -65,24 +65,24 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>4.8.0</Version>
+      <Version>4.11.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>4.8.0</Version>
+      <Version>4.11.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>4.8.0</Version>
+      <Version>4.11.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.7.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.8.37222" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Threading">
-      <Version>17.8.14</Version>
+      <Version>17.0.63</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.8.2365">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.11.435">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -118,4 +118,11 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Target Name="IncludeNuGetPackageReferences" AfterTargets="GetVsixSourceItems">
+    <ItemGroup>
+      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Microsoft.CodeAnalysis'" />
+      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Microsoft.CodeAnalysis.Common'" />
+      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Microsoft.CodeAnalysis.CSharp'" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/RoslyJump.VSIX.2022/RoslyJump.VSIX.2022.csproj
+++ b/RoslyJump.VSIX.2022/RoslyJump.VSIX.2022.csproj
@@ -79,6 +79,9 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.8.37222" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Threading">
+      <Version>17.8.14</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.8.2365">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/RoslyJump.VSIX.2022/RoslyJump.VSIX.2022.csproj
+++ b/RoslyJump.VSIX.2022/RoslyJump.VSIX.2022.csproj
@@ -120,10 +120,7 @@
   -->
   <Target Name="IncludeNuGetPackageReferences" AfterTargets="GetVsixSourceItems">
     <ItemGroup>
-      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Microsoft.CodeAnalysis'" />
-      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Microsoft.CodeAnalysis.Common'" />
-      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Microsoft.CodeAnalysis.CSharp'" />
-      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'System.Collections.Immutable'" />
+      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)"/>
     </ItemGroup>
   </Target>
 </Project>

--- a/RoslyJump.VSIX.2022/RoslyJump.VSIX.2022.csproj
+++ b/RoslyJump.VSIX.2022/RoslyJump.VSIX.2022.csproj
@@ -123,6 +123,7 @@
       <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Microsoft.CodeAnalysis'" />
       <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Microsoft.CodeAnalysis.Common'" />
       <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Microsoft.CodeAnalysis.CSharp'" />
+      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'System.Collections.Immutable'" />
     </ItemGroup>
   </Target>
 </Project>

--- a/RoslyJump/RoslyJump.VSIX.2019.csproj
+++ b/RoslyJump/RoslyJump.VSIX.2019.csproj
@@ -72,10 +72,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>3.7.0</Version>
+      <Version>4.8.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>3.7.0</Version>
+      <Version>4.8.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.0.0</Version>

--- a/RoslyJump/RoslyJump.VSIX.2019.csproj
+++ b/RoslyJump/RoslyJump.VSIX.2019.csproj
@@ -81,6 +81,9 @@
       <Version>4.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading">
+      <Version>16.10.56</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.8.3038" />
     <PackageReference Include="System.ComponentModel.Composition">
       <Version>4.7.0</Version>

--- a/RoslyJump/RoslyJump.VSIX.2019.csproj
+++ b/RoslyJump/RoslyJump.VSIX.2019.csproj
@@ -72,21 +72,24 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common">
-      <Version>4.8.0</Version>
+      <Version>4.11.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-      <Version>4.8.0</Version>
+      <Version>4.11.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.Threading">
-      <Version>16.10.56</Version>
+      <Version>16.0.102</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.8.3038" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.11.69">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="System.ComponentModel.Composition">
-      <Version>4.7.0</Version>
+      <Version>8.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
@@ -122,4 +125,11 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Target Name="IncludeNuGetPackageReferences" AfterTargets="GetVsixSourceItems">
+    <ItemGroup>
+      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Microsoft.CodeAnalysis'" />
+      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Microsoft.CodeAnalysis.Common'" />
+      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Microsoft.CodeAnalysis.CSharp'" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/RoslyJump/RoslyJump.VSIX.2019.csproj
+++ b/RoslyJump/RoslyJump.VSIX.2019.csproj
@@ -127,9 +127,7 @@
   -->
   <Target Name="IncludeNuGetPackageReferences" AfterTargets="GetVsixSourceItems">
     <ItemGroup>
-      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Microsoft.CodeAnalysis'" />
-      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Microsoft.CodeAnalysis.Common'" />
-      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' == 'Microsoft.CodeAnalysis.CSharp'" />
+      <VSIXSourceItem Include="@(ReferenceCopyLocalPaths)"/>
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Seems like there were two reasons why the extension wasn't able to load on both VS2019 and VS2022:

1. Due to version of `Microsoft.VisualStudio.Threading` required being higher than installed
2. `Microsoft.CodeAnalysis.CSharp` and other dlls were not copied to the `vsix`
3. Mismatched version of `CodeAnalysis` packages in `dngrep`

Both of those issues should be addressed in this PR. There are probably more subtle ways to fix it, but it should be fine for now.

> Notice: with this PR all `.dlls` are copied into `vsix` respective packages, which increases their download size. It resolves the issue with missing `NuGet` packages on older versions of Visual Studio 2022/2019 and/or when such packages are not installed and/or not in GAC and/or when they have mismatched version.