### PR TITLE
Fix extension icon is too small

### DIFF
--- a/RoslyJump.VSIX.2022/RoslyJump.VSIX.2022.csproj
+++ b/RoslyJump.VSIX.2022/RoslyJump.VSIX.2022.csproj
@@ -107,11 +107,6 @@
       <Link>RoslyJump.vsct</Link>
       <ResourceName>Menus.ctmenu</ResourceName>
     </VSCTCompile>
-    <Content Include="..\Shared\icon-32x32.png">
-      <Link>icon-32x32.png</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
     <Content Include="..\Shared\preview-200x200.png">
       <Link>preview-200x200.png</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/RoslyJump.VSIX.2022/source.extension.vsixmanifest
+++ b/RoslyJump.VSIX.2022/source.extension.vsixmanifest
@@ -5,7 +5,7 @@
         <DisplayName>RoslyJump 2022</DisplayName>
         <Description xml:space="preserve">Mouseless Code Navigation for C# and Visual Studio 2022.</Description>
         <License>License.txt</License>
-        <Icon>icon-32x32.png</Icon>
+        <Icon>preview-200x200.png</Icon>
         <PreviewImage>preview-200x200.png</PreviewImage>
     </Metadata>
     <Installation>

--- a/RoslyJump/RoslyJump.VSIX.2019.csproj
+++ b/RoslyJump/RoslyJump.VSIX.2019.csproj
@@ -114,11 +114,6 @@
       <Link>RoslyJump.vsct</Link>
       <ResourceName>Menus.ctmenu</ResourceName>
     </VSCTCompile>
-    <Content Include="..\Shared\icon-32x32.png">
-      <Link>icon-32x32.png</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
-    </Content>
     <Content Include="..\Shared\preview-200x200.png">
       <Link>preview-200x200.png</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/RoslyJump/source.extension.vsixmanifest
+++ b/RoslyJump/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
         <Description xml:space="preserve">Mouseless Code Navigation for C# and Visual Studio 2019.</Description>
         <MoreInfo>https://github.com/psxvoid/RoslyJump</MoreInfo>
         <License>License.txt</License>
-        <Icon>icon-32x32.png</Icon>
+        <Icon>preview-200x200.png</Icon>
         <PreviewImage>preview-200x200.png</PreviewImage>
     </Metadata>
     <Installation>


### PR DESCRIPTION
Notes:
- the icon is used on the marketplace and is too small

Though, the docs says it should be 32x32, most likely the docs are outdated.